### PR TITLE
Adds support for Really Old Clients

### DIFF
--- a/MapleNecrocer/Client/MapleCharacter.cs
+++ b/MapleNecrocer/Client/MapleCharacter.cs
@@ -187,13 +187,13 @@ public class Player : JumperSprite
         }
 
 
-        string[] DefaultEqps = { "01302000", "00002000", "01060002", "01070000", "01040005", "00020000", "00030020", "00012000" };
+        string[] DefaultEqps = { "01302000", "00002000", "01060002", "01072000", "01040005", "00020000", "00030020", "00012000" };
         for (int I = 0; I <= 7; I++)
         {
             Game.Player.CreateEquip(DefaultEqps[I], Game.Player.AvatarEngine);
             Player.EqpList.Add(DefaultEqps[I]);
         }
-        Wz.DumpData(Wz.GetNodeA("Character/00002001.img"), Wz.EquipData, Wz.EquipImageLib);
+        Wz.DumpData(Wz.GetNodeA("Character/00002000.img"), Wz.EquipData, Wz.EquipImageLib);
 
         Game.Player.AttackAction = Game.Player.AttackActions[0];
         AfterImage.Load(Game.Player.AfterImageStr, "0");

--- a/MapleNecrocer/Client/MapleEffect.cs
+++ b/MapleNecrocer/Client/MapleEffect.cs
@@ -31,17 +31,20 @@ public class SetEffect : SpriteEx
     public static Dictionary<string, SetEffect> UseList = new();
     public static void LoadList()
     {
-        foreach (var Iter in Wz.GetNodeA("Effect/SetEff.img").Nodes)
+        if (Wz.HasNode("Effect/SetEff.img"))
         {
-            foreach (var Iter2 in Iter.Nodes)
+            foreach (var Iter in Wz.GetNodeA("Effect/SetEff.img").Nodes)
             {
-                if (Iter2.Text == "info")
+                foreach (var Iter2 in Iter.Nodes)
                 {
-                    foreach (var Iter3 in Iter2.Nodes)
+                    if (Iter2.Text == "info")
                     {
-                        foreach (var Iter4 in Iter3.Nodes)
+                        foreach (var Iter3 in Iter2.Nodes)
                         {
-                            SetEffect.AllList.AddOrReplace("0" + Iter4.ToInt(), Iter.Text);
+                            foreach (var Iter4 in Iter3.Nodes)
+                            {
+                                SetEffect.AllList.AddOrReplace("0" + Iter4.ToInt(), Iter.Text);
+                            }
                         }
                     }
                 }

--- a/MapleNecrocer/Client/MapleMap.cs
+++ b/MapleNecrocer/Client/MapleMap.cs
@@ -147,7 +147,13 @@ public class Map
 
         //
         string LeftNum = ID.LeftStr(1);
-        Map.Img = Wz.GetNode("Map/Map/Map" + LeftNum + "/" + ID + ".img");
+        if (Wz.HasHardCodedStrings)
+        {
+            Map.Img = Wz.GetNode("Map/Map/" + ID + ".img");
+        } else
+        {
+            Map.Img = Wz.GetNode("Map/Map/Map" + LeftNum + "/" + ID + ".img");
+        }
 
 
         Map.Info.Clear();
@@ -206,7 +212,9 @@ public class Map
       
         if (!FirstLoaded)
         {
-            string Name = Wz.GetNode("String/Mob.img/100100/name").ToStr();
+            string StringPath = Wz.HasHardCodedStrings ? "Mob/0100100.img/info/name" : "String/Mob.img/100100/name";
+
+            string Name = Wz.GetNode(StringPath).ToStr();
             switch (Name)
             {
                 case "Snail":
@@ -246,7 +254,7 @@ public class Map
             Player.SpawnNew();
             NameTag.Create("SuperGM");
             GameCursor.LoadRes("0");
-            if (Wz.HasNode("UI/Basic.img/Cursor/12"))
+            if (!Wz.IsDataWz && Wz.HasNode("UI/Basic.img/Cursor/12"))
                 GameCursor.LoadRes("12");
             else
                 GameCursor.IsDataWz = true;
@@ -254,6 +262,8 @@ public class Map
             UI.ControlManager.Controls.Add(MiniMap);
             if(Wz.HasNode("UI/UIWindow4.img"))
                 MiniMap.Version=3;
+            else if (Wz.HasNode("UI/UIWindow.img/MiniMap/e"))
+                MiniMap.Version=0;
             else
                 MiniMap.Version=1;
             FirstLoaded = true;

--- a/MapleNecrocer/Client/Mob.cs
+++ b/MapleNecrocer/Client/Mob.cs
@@ -204,7 +204,13 @@ public class Mob : JumperSprite
         if (ImgNode.GetInt("info/noFlip").ToBool())
             Mob.FlipX = false;
         Mob.LevelWidth = Map.MeasureStringX(Map.MobLvFont, "Lv." + Mob.Level);
-        Mob.MobName = Wz.GetNodeA("String/Mob.img/" + Mob.LocalID.IntID()).GetStr("name");
+        if (Wz.HasHardCodedStrings)
+        {
+            Mob.MobName = Wz.GetNodeA("Mob/" + Mob.LocalID + ".img/info").GetStr("name");
+        } else
+        {
+            Mob.MobName = Wz.GetNodeA("String/Mob.img/" + Mob.LocalID.IntID()).GetStr("name");
+        }
         Mob.NameWidth = Map.MeasureStringX(Map.NpcNameTagFont, Mob.MobName);
         Mob.IDWidth = Map.MeasureStringX(Map.NpcNameTagFont, "ID:" + Mob.LocalID);
         Mob.NameTagWidth = 10 + Mob.LevelWidth + Mob.NameWidth;
@@ -245,7 +251,8 @@ public class Mob : JumperSprite
     }
 
     public override void DoMove(float Delta)
-    {
+    {  
+       
         base.DoMove(Delta);
 
         int X1 = FH.X1;

--- a/MapleNecrocer/Client/Npc.cs
+++ b/MapleNecrocer/Client/Npc.cs
@@ -64,7 +64,8 @@ public class Npc : SpriteEx
     }
     public static void Spawn(string ID, int PosX, int PosY, int FlipX)
     {
-        if (Wz.GetNodeA("String/Npc.img/" + ID.IntID()) == null)
+        string npcStringPath = Wz.HasHardCodedStrings ? "Npc/" + ID + ".img/info" : "String/Npc.img/" + ID.IntID();
+        if (Wz.GetNodeA(npcStringPath) == null)
             return;
         switch (ID.ToInt())
         {
@@ -117,7 +118,8 @@ public class Npc : SpriteEx
         Npc.Width = Npc.ImageWidth;
         Npc.Height = Npc.ImageHeight;
 
-        foreach (var Iter2 in Wz.GetNode("String/Npc.img/" + Npc.SpriteID.IntID()).Nodes)
+        npcStringPath = Wz.HasHardCodedStrings ? "Npc/" + Npc.SpriteID + ".img/info" : "String/Npc.img/" + Npc.SpriteID.IntID();
+        foreach (var Iter2 in Wz.GetNode(npcStringPath).Nodes)
         {
             if (Iter2.Text.Length == 2)
             {
@@ -167,8 +169,8 @@ public class Npc : SpriteEx
         }
         //
         var NpcText = new NpcText(EngineFunc.SpriteEngine);
-        NpcText.NpcName = Wz.GetNodeA("String/Npc.img/" + Npc.LocalID.IntID()).GetStr("name");
-        NpcText.NpcFunc = Wz.GetNodeA("String/Npc.img/" + Npc.LocalID.IntID()).GetStr("func");
+        NpcText.NpcName = Wz.GetNodeA(npcStringPath).GetStr("name");
+        NpcText.NpcFunc = Wz.GetNodeA(npcStringPath).GetStr("func");
         if (NpcText.NpcFunc != "")
             NpcText.HasFunc = true;
         NpcText.X = Pos.X;

--- a/MapleNecrocer/Client/UI/GameCursor.cs
+++ b/MapleNecrocer/Client/UI/GameCursor.cs
@@ -17,7 +17,14 @@ public class GameCursor
     //static Wz_Node ImagEntry;
     public static void LoadRes(string CursorNum)
     {
-        Wz.DumpData(Wz.GetNode("UI/Basic.img/Cursor/" + CursorNum), Wz.UIData, Wz.UIImageLib);
+        if(Wz.HasNode("UI/Basic.img/Cursor/" + CursorNum))
+        {
+            Wz.DumpData(Wz.GetNode("UI/Basic.img/Cursor/" + CursorNum), Wz.UIData, Wz.UIImageLib);
+        } else
+        {
+            // Fallback for older clients
+            Wz.DumpData(Wz.GetNode("UI/Basic.img/Cursor/arrow"), Wz.UIData, Wz.UIImageLib);
+        }
     }
 
     public static void Draw()
@@ -53,7 +60,14 @@ public class GameCursor
         }
         else
         {
-            ImageNode = Wz.UIData["UI/Basic.img/Cursor/" + CursorNumber + "/0"];
+            if (Wz.UIData.ContainsKey("UI/Basic.img/Cursor/" + CursorNumber + "/0"))
+            {
+                ImageNode = Wz.UIData["UI/Basic.img/Cursor/" + CursorNumber + "/0"];
+            } else
+            {
+                // It's most likely the /arrow
+                ImageNode = Wz.UIData["UI/Basic.img/Cursor/arrow"];
+            }
             Wz_Vector Origin = ImageNode.GetVector("origin");
             int OffsetX = -Origin.X + 3;
             int OffsetY = -Origin.Y + 3;

--- a/MapleNecrocer/NpcForm.cs
+++ b/MapleNecrocer/NpcForm.cs
@@ -75,8 +75,9 @@ public partial class NpcForm : Form
             if (!Char.IsNumber(Iter.Text, 0))
                 continue;
             ID = Iter.Text.LeftStr(7);
-            if (Wz.GetNodeA("String/Npc.img/" + ID.IntID()) != null)
-                Name = Wz.GetNodeA("String/Npc.img/" + ID.IntID()).GetStr("name");
+            string npcStringPath = Wz.HasHardCodedStrings ? "Npc/" + ID + ".img/info" : "String/Npc.img/" + ID.IntID();
+            if (Wz.GetNodeA(npcStringPath) != null)
+                Name = Wz.GetNodeA(npcStringPath).GetStr("name");
             NpcListGrid.Rows.Add(ID, Name);
 
         }

--- a/MapleNecrocer/SelectFolderForm.cs
+++ b/MapleNecrocer/SelectFolderForm.cs
@@ -106,7 +106,9 @@ public partial class SelectFolderForm : Form
 
                 MainForm.OpenWZ(FindBaseWz.First());
 
-                if (Wz.GetNode("String/Mob.img/100100/name").ToStr() == "Snail")
+                string StringPath = Wz.HasHardCodedStrings ? "Mob/0100100.img/info/name" : "String/Mob.img/100100/name";
+                
+                if (Wz.GetNode(StringPath).ToStr() == "Snail")
                 {
                     MainForm.Instance.MapListBox.Columns[0].Width = 72;
                     MainForm.Instance.MapListBox.Font = new Font("Arial", 13f, GraphicsUnit.Pixel);
@@ -155,7 +157,8 @@ public partial class SelectFolderForm : Form
 
         if (FindBaseWz.Count() >= 1)
             MainForm.OpenWZ(FindBaseWz.First());
-        if (Wz.GetNode("String/Mob.img/100100/name").ToStr() == "Snail")
+        string StringPath = Wz.HasHardCodedStrings ? "Mob/0100100.img/info/name" : "String/Mob.img/100100/name";
+        if (Wz.GetNode(StringPath).ToStr() == "Snail")
         {
             MainForm.Instance.MapListBox.Columns[0].Width = 72;
             MainForm.Instance.MapListBox.Font = new Font("Arial", 13f, GraphicsUnit.Pixel);

--- a/MapleNecrocer/WzUtils.cs
+++ b/MapleNecrocer/WzUtils.cs
@@ -46,6 +46,7 @@ internal class Wz
     public static Dictionary<string, Wz_Node> UIData = new Dictionary<string, Wz_Node>();
     public static string Region;
     public static bool HasStringWz;
+    public static bool HasHardCodedStrings = false;
     //very old Data.wz has no Map1,Map2,Map3... dir
     public static bool HasMap9Dir;
     public static bool IsDataWz;
@@ -314,6 +315,7 @@ internal class Wz
         {
             string[] Split = Path.Split('/');
             var Node2 = PluginManager.FindWz(Split[0]);
+            if (Node2 == null) return null;
             int Count = 0;
             string Str = "";
             string Path1 = "";


### PR DESCRIPTION
Hello!
I open this PR to add support for really old versions, such as KMS 1.21. These versions have what I call "HardCodedStrings", which contain the Map, Character, Mobs, etc etc strings inside the `info` folder in the .img item.
Apart from that, there's less items, so I had to remove the shoe to an item available in all versions. Also, the cursor is named differently from other versions and the minimap doesn't have the map name and information, so it looks a bit weird.

The PR also solves some issues when opening clients that don't have the `Map0~Map9` layout on Map/Data.wz. That was being correctly detected with the WzUtils' `HasMap9Dir` set in false, but it wasn't being used.

There's a built binary in case you want to test it out!
[MapleNecrocerWithOldSupport.zip](https://github.com/user-attachments/files/17822523/MapleNecrocerWithOldSupport.zip)

And in case you want a reaaally old KMS client, check 1.21 which is one of the oldest available clients: https://mega.nz/file/9p1xWKRT#V8TodI8Y2cBNnH2yQs9fQOPUkIFyD2kjdi5tU25lflE
