### PR TITLE
Added the way KMS 168 handles cursor loading

### DIFF
--- a/MapleNecrocer/Client/UI/GameCursor.cs
+++ b/MapleNecrocer/Client/UI/GameCursor.cs
@@ -17,12 +17,15 @@ public class GameCursor
     //static Wz_Node ImagEntry;
     public static void LoadRes(string CursorNum)
     {
-        if(Wz.HasNode("UI/Basic.img/Cursor/" + CursorNum))
+        if (Wz.HasNode("UI/Basic.img/Cursor/" + CursorNum))
         {
             Wz.DumpData(Wz.GetNode("UI/Basic.img/Cursor/" + CursorNum), Wz.UIData, Wz.UIImageLib);
-        } else
-        {
-            // Fallback for older clients
+        } else if(Wz.HasNode("UI/Basic.img/Cursor/arrow/" + CursorNum)) {
+            // Fallback for older clients, with arrow/0 cursor available only.
+            Wz.DumpData(Wz.GetNode("UI/Basic.img/Cursor/arrow/" + CursorNum), Wz.UIData, Wz.UIImageLib);
+
+        } else {
+            // Fallback for REALLY old clients
             Wz.DumpData(Wz.GetNode("UI/Basic.img/Cursor/arrow"), Wz.UIData, Wz.UIImageLib);
         }
     }
@@ -63,8 +66,9 @@ public class GameCursor
             if (Wz.UIData.ContainsKey("UI/Basic.img/Cursor/" + CursorNumber + "/0"))
             {
                 ImageNode = Wz.UIData["UI/Basic.img/Cursor/" + CursorNumber + "/0"];
-            } else
-            {
+            } else if (Wz.UIData.ContainsKey("UI/Basic.img/Cursor/arrow/" + CursorNumber)) {
+                ImageNode = Wz.UIData["UI/Basic.img/Cursor/arrow/" + CursorNumber];
+            } else {
                 // It's most likely the /arrow
                 ImageNode = Wz.UIData["UI/Basic.img/Cursor/arrow"];
             }


### PR DESCRIPTION
Hello Again!
I downloaded more old KMS clients to check if your emulator is working with all, and found a version that doesn't. This particular case (KMS v168) has a problem when loading the cursors. Similar to v1.21, the cursor is located in `UI/Basic.img/Cursor/arrow` but this time, it has subfolders. Only `UI/Basic.img/Cursor/arrow/0` though, where the icon is. So, for this version, we are using CursorNum to load the subfolder.

I'll continue to check on more edge cases on my spare time since this is fun to do, so your emulator can handle pretty much all versions. I really loved it, have been using it since the delphi version ^^

Have a great week~